### PR TITLE
Add oak-ajax-behavior

### DIFF
--- a/birch-watch.html
+++ b/birch-watch.html
@@ -9,6 +9,7 @@ Display and or Update a FamilySearch Person&#39;s Watch status
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../wc-i18n/wc-i18n.html">
 <link rel="import" href="../oak-i18n-behavior/oak-i18n-behavior.html">
+<link rel="import" href="../oak-ajax-behavior/oak-ajax-behavior.html">
 
 
 <dom-module id="birch-watch">
@@ -94,7 +95,8 @@ Display and or Update a FamilySearch Person&#39;s Watch status
 
       behaviors: [
         WCI18n(),
-        OakI18nBehavior
+        OakI18nBehavior,
+        OakAJAXBehavior
       ],
 
       properties: {
@@ -124,7 +126,7 @@ Display and or Update a FamilySearch Person&#39;s Watch status
       _watching: undefined,
 
       observers: [
-        'getWatchStatus(pid, classicReferenceId, watcherCisId)'
+        'getWatchStatus(pid, classicReferenceId, watcherCisId, sessionId)'
       ],
 
       /**
@@ -134,10 +136,10 @@ Display and or Update a FamilySearch Person&#39;s Watch status
        * @param {String} classicReferenceId The id of the current reference (int, beta, prod, etc.)
        * @param {String} watcherCisId The CIS ID of the person who is watching
        */
-      getWatchStatus: function(pid, classicReferenceId, watcherCisId) {
-          if (pid && classicReferenceId && watcherCisId) {
+      getWatchStatus: function(pid, classicReferenceId, watcherCisId, sessionId) {
+          if (pid && classicReferenceId && watcherCisId && sessionId) {
             var resourceId = pid + classicReferenceId;
-            var watchStatusUrl = '/watch/watches' + '?resourceId=' + resourceId + '&watcher=' + watcherCisId;
+            var watchStatusUrl = this.ajaxBase+'/watch/watches' + '?resourceId=' + resourceId + '&watcher=' + watcherCisId+ '&sessionId=' + sessionId;
             var watchStatusConfig = {
               method: 'HEAD',
               credentials: 'same-origin'
@@ -211,7 +213,7 @@ Display and or Update a FamilySearch Person&#39;s Watch status
        */
       _watch: function (pid, classicReferenceId) {
         var resourceId = pid + classicReferenceId;
-        var url = "/watch/watch";
+        var url = this.ajaxBase+"/watch/watch?sessionId="+this.sessionId;
         var config = {
           method: 'POST',
           headers: new Headers({'content-type': 'application/json'}),
@@ -238,9 +240,9 @@ Display and or Update a FamilySearch Person&#39;s Watch status
        * @param {String} watcherCisId The CIS ID of the person who is watching
        */
       _unwatch: function (pid, classicReferenceId, watcherCisId) {
-        var WATCH_STATUS_ENDPOINT = "/watch/watches";
+        var WATCH_STATUS_ENDPOINT = this.ajaxBase+"/watch/watches";
         var resourceId = pid + classicReferenceId;
-        var queryString = '?resourceId=' + resourceId + '&watcher=' + watcherCisId;
+        var queryString = '?resourceId=' + resourceId + '&watcher=' + watcherCisId + '&sessionId=' + this.sessionId;
         var url = WATCH_STATUS_ENDPOINT + queryString;
         var config = {
           method: 'DELETE',

--- a/test/birch-watch_test.html
+++ b/test/birch-watch_test.html
@@ -51,20 +51,24 @@
           myEl.pid = "TEST-PID"; //This fires the getWatchStatus function.
           myEl.classicReferenceId = "REFERENCE_ID";
           myEl.watcherCisId = null;
+          myEl.sessionId = null;
           verifyStatus(myEl._watchStatus, myEl._status.unavailable);
 
           myEl.pid = "";
           myEl.watcherCisId = "WATCHER";
           myEl.classicReferenceId = "REFERENCE";
+          myEl.sessionId = null;
           verifyStatus(myEl._watchStatus, myEl._status.unavailable);
 
           myEl.watcherCisId = "";
           myEl.pid = "PID";
+          myEl.sessionId = null;
           verifyStatus(myEl._watchStatus, myEl._status.unavailable);
 
 
           myEl.classicReferenceId = "";
           myEl.watcherCisId = "WATCHER";
+          myEl.sessionId = null;
           verifyStatus(myEl._watchStatus, myEl._status.unavailable);
 
           done();
@@ -73,14 +77,15 @@
       });
 
       test('getWatchStatus', function(done) {
-        fetchMock.mock({matcher:'/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID', response:200, method:'HEAD'});
+        fetchMock.mock({matcher:'https://integration.familysearch.org/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID&sessionId=SESSION_ID', response:200, method:'HEAD'});
         var fetchSpy = sinon.spy(window, 'fetch');
 
         myEl.pid = "TEST-PID"; //This fires the getWatchStatus function.
         myEl.classicReferenceId = "REFERENCE_ID";
         myEl.watcherCisId = "CIS_ID";
+        myEl.sessionId = "SESSION_ID";
         expect(fetchSpy).calledOnce;
-        assert.equal("/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID", fetchSpy.args[0][0]);
+        assert.equal("https://integration.familysearch.org/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID&sessionId=SESSION_ID", fetchSpy.args[0][0]);
         assert.equal("HEAD", fetchSpy.args[0][1].method);
         assert.equal("same-origin", fetchSpy.args[0][1].credentials);
         flush(function() {
@@ -93,14 +98,15 @@
       });
 
       test('toggleWatch', function(done) {
-        fetchMock.mock({matcher:'/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID', response:200, method:'HEAD'});
-        fetchMock.mock({matcher:'/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID', response:200, method:'DELETE'});
+        fetchMock.mock({matcher:'https://integration.familysearch.org/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID&sessionId=SESSION_ID', response:200, method:'HEAD'});
+        fetchMock.mock({matcher:'https://integration.familysearch.org/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID&sessionId=SESSION_ID', response:200, method:'DELETE'});
 
         var callWatchSpy = sinon.spy(myEl, '_unwatch');
 
         myEl.pid = "TEST-PID"; //This fires the getWatchStatus function.
         myEl.classicReferenceId = "REFERENCE_ID";
         myEl.watcherCisId = "CIS_ID";
+        myEl.sessionId = "SESSION_ID";
 
         flush(function () {
           verifyStatus(myEl._watchStatus, myEl._status.watching);
@@ -120,14 +126,15 @@
       });
 
       test('toggleUnwatch', function(done) {
-        fetchMock.mock({matcher:'/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID', response:200, method:'HEAD'});
-        fetchMock.mock({matcher:'/watch/watch', response:201, method:'POST'});
+        fetchMock.mock({matcher:'https://integration.familysearch.org/watch/watches?resourceId=TEST-PIDREFERENCE_ID&watcher=CIS_ID&sessionId=SESSION_ID', response:200, method:'HEAD'});
+        fetchMock.mock({matcher:'https://integration.familysearch.org/watch/watch?sessionId=SESSION_ID', response:201, method:'POST'});
 
         var callWatchSpy = sinon.spy(myEl, '_watch');
 
         myEl.pid = "TEST-PID";
         myEl.classicReferenceId = "REFERENCE_ID";
         myEl.watcherCisId = "CIS_ID";
+        myEl.sessionId = "SESSION_ID";
 
         flush(function () {
           verifyStatus(myEl._watchStatus, myEl._status.watching);


### PR DESCRIPTION
## Changes
* Add dep on `oak-ajax-behavior`
  * This allows us to set the base url and session id when running standalone (our polymer demos)

## Issues
**Watching** and **Uwatching** doesn't work for some reason. Getting an error back from the server. Not sure why.
