### PR TITLE
Bump version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "description": "Display Watch Status of a FamilySearch Person",
   "main": "birch-watch.html",
   "license": "MIT",
+  "version": "0.0.1",
   "ignore": [
     "/.*",
     "/test/"


### PR DESCRIPTION
I ran `bower version patch` in the last PR and since there was no version in `bower.json`, bower just created an empty commit. Dumb `bower`. This is making it so we can't pin to `0.0.1` even though the release exists in github.