### PR TITLE
Observe ajaxBase and authHeaders

### DIFF
--- a/birch-watch.html
+++ b/birch-watch.html
@@ -126,7 +126,7 @@ Display and or Update a FamilySearch Person&#39;s Watch status
       _watching: undefined,
 
       observers: [
-        'getWatchStatus(pid, classicReferenceId, watcherCisId, sessionId)'
+        'getWatchStatus(pid, classicReferenceId, watcherCisId, ajaxBase, authHeaders)'
       ],
 
       /**
@@ -136,10 +136,13 @@ Display and or Update a FamilySearch Person&#39;s Watch status
        * @param {String} classicReferenceId The id of the current reference (int, beta, prod, etc.)
        * @param {String} watcherCisId The CIS ID of the person who is watching
        */
-      getWatchStatus: function(pid, classicReferenceId, watcherCisId, sessionId) {
-          if (pid && classicReferenceId && watcherCisId && sessionId) {
+      getWatchStatus: function(pid, classicReferenceId, watcherCisId, ajaxBase, authHeaders) {
+          if (pid && classicReferenceId && watcherCisId && this.sessionId) {
+            var _sessionId = this.sessionId;
+            var _authHeaders = this.authHeaders;
+            var _ajaxBase = this.ajaxBase;
             var resourceId = pid + classicReferenceId;
-            var watchStatusUrl = this.ajaxBase+'/watch/watches' + '?resourceId=' + resourceId + '&watcher=' + watcherCisId+ '&sessionId=' + sessionId;
+            var watchStatusUrl = _ajaxBase+'/watch/watches' + '?resourceId=' + resourceId + '&watcher=' + watcherCisId+ '&sessionId=' + _sessionId;
             var watchStatusConfig = {
               method: 'HEAD',
               credentials: 'same-origin'

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,9 @@
 {
   "name": "birch-watch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Display Watch Status of a FamilySearch Person",
   "main": "birch-watch.html",
   "license": "MIT",
-  "version": "0.0.1",
   "ignore": [
     "/.*",
     "/test/"


### PR DESCRIPTION
For some reason, observing `sessionId` doesn't work with `oak-ajax-behavior`. Moving to `authHeaders`